### PR TITLE
Fix broken Anchor links in list of commands article (CLI 2.x)

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -2377,14 +2377,14 @@ CloudHub は、オンライン証明書状況プロトコル (OCSP) を実装し
 このコマンドは、サポートされているすべてのランタイムをリストします。 +
 このコマンドでは、デフォルトのオプション (`--help`、`-f`/`--fields`、`-o`/`--output`) 以外のオプションは使用できません。
 
-== cloudhub VPC list
+== cloudhub vpc list
 
 ----
-> cloudhub VPC list [options]
+> cloudhub vpc list [options]
 ----
 このコマンドは、使用可能なすべての Anypoint VPC をリストします。ID、リージョン、ネットワークの環境、およびデフォルトの Anypoint VPC かどうかを返します。
 
-== cloudhub VPC describe
+== cloudhub vpc describe
 
 ----
 > cloudhub vpc describe [options] <name>

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -383,7 +383,7 @@ $ anypoint-cli [params] [command]
 
 このコマンドでは、デフォルトのオプション (`--help`、`-f`/`--fields`、`-o`/`--output`) 以外のオプションは使用できません。
 
-== account environment delete
+== account environment describe
 
 ----
 > account environment describe [options] <name>

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -2,20 +2,20 @@
 
 Anypoint Platform CLI には、さまざまなユースケースシナリオに対応するコマンドが用意されています。
 
-* <<Commands For Administrating your Anypoint Platform Account>>
-* <<Commands for API Manager>>
-* <<Commands for Administrating your Design Center Applications>>
-* <<Commands for Managing Exchange Assets>>
-* <<Commands for Administrating your CloudHub Application>>
-* <<Commands for Managing your Locally Deployed Applications Managed by Runtime Manager>>
-* <<Commands for Managing Your Local Pivotal Cloud Foundry Deployed Applications>>
-* <<Commands for Managing your Local Servers>>
-* <<Commands for Administrating your Local Server Groups>>
-* <<Commands for Administrating your Local Cluster Servers>>
-* <<Commands for Managing Alerts for your Locally Deployed Applications Managed by Runtime Manager>>
-* <<Commands for Mananging your CloudHub Dedicated Load balancer>>
-* <<Commands for Managing your CloudHub Anypoint VPC>>
-* <<Commands for Specifying Environments and Business Groups>>
+* <<platform-account-commands,Anypoint Platform アカウントを管理するコマンド>>
+* <<api-manager-commands,API Manager のコマンド>>
+* <<design-center-applications-commands,Design Center アプリケーションを管理するコマンド>>
+* <<exchange-assets-commands,Exchange アセットを管理するコマンド>>
+* <<cloudhub-application-commands,CloudHub アプリケーションを管理するコマンド>>
+* <<local-applications-runtime-manager-commands,Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションを管理するコマンド>>
+* <<local-pcf-applications-commands,ローカル Pivotal Cloud Foundry デプロイ済みアプリケーションを管理するコマンド>>
+* <<local-servers-commands,ローカルサーバを管理するコマンド>>
+* <<local-server-groups-commands,ローカルサーバグループを管理するコマンド>>
+* <<local-cluster-servers-commands,ローカルクラスタサーバを管理するコマンド>>
+* <<alerts-local-applications-runtime-manager-commands,Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションのアラートを管理するコマンド>>
+* <<cloudhub-dedicated-load-balancer-commands,CloudHub 専用ロードバランサを管理するコマンド>>
+* <<cloudhub-vpc-commands,CloudHub VPC を管理するコマンド>>
+* <<environments-and-business-groups-commands,環境およびビジネスグループを指定するコマンド>>
 
 
 [TIP]
@@ -29,6 +29,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 コマンドの後に `--fields` オプションを渡して、出力可能なすべての項目のリストを取得できます。
 --
 
+[#platform-account-commands]
 == Anypoint Platform アカウントを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -43,6 +44,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<account environment describe>> | 環境の詳細を表示する
 |===
 
+[#api-manager-commands]
 == API Manager のコマンド
 
 [%header,cols="35a,65a"]
@@ -78,6 +80,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<api-mgr tier list>> | API インスタンスの SLA 層をリストする
 |===
 
+[#design-center-applications-commands]
 == Design Center アプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -91,6 +94,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 | <<designcenter project list>> | すべての Design Center プロジェクトをリストする
 |===
 
+[#exchange-assets-commands]
 == Exchange アセットを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -112,6 +116,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<exchange asset describe>> | 特定のアセットの情報を表示する
 |===
 
+[#cloudhub-application-commands]
 == CloudHub アプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -136,6 +141,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 // |<<runtime-mgr cloudhub-application downgrade-runtime>>| Downgrades application runtime to the previous runtime version or if a version is specified, to that version.
 |===
 
+[#local-applications-runtime-manager-commands]
 == Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションを管理するコマンド
 
 [CAUTION]
@@ -157,7 +163,8 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr standalone-application copy>> | スタンドアロンアプリケーションをコピーする
 |===
 
-== ローカル Anypoint Platform for Pivotal Cloud Foundry (PCF) デプロイ済みアプリケーションを管理するコマンド
+[#local-pcf-applications-commands]
+== ローカル Pivotal Cloud Foundry デプロイ済みアプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
 |===
@@ -175,6 +182,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |===
 
 
+[#local-servers-commands]
 == ローカルサーバを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -188,6 +196,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 // |<<runtime-mgr server register>> | Registers a new server. Returns a signed certificate which is downloaded to the `directory` path
 |===
 
+[#local-server-groups-commands]
 == ローカルサーバグループを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -202,6 +211,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr serverGroup remove server>> | サーバグループのサーバを削除する
 |===
 
+[#local-cluster-servers-commands]
 == ローカルクラスタサーバを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -216,7 +226,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr cluster modify>> | クラスタを変更する
 |===
 
-
+[#alerts-local-applications-runtime-manager-commands]
 == Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションのアラートを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -228,6 +238,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr standalone-alert list>> | 環境内のスタンドアロンランタイムのすべてのアラートをリストする
 |===
 
+[#cloudhub-dedicated-load-balancer-commands]
 == CloudHub 専用ロードバランサを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -255,7 +266,8 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<cloudhub runtime list>>| 使用可能なすべてのランタイムをリストする
 |===
 
-== CloudHub Anypoint VPC を管理するコマンド
+[#cloudhub-vpc-commands]
+== CloudHub VPC を管理するコマンド
 
 [%header,cols="35a,65a"]
 |===
@@ -276,6 +288,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<cloudhub vpc firewall-rules remove>>| この Anypoint VPC の Mule アプリケーションのファイアウォールルールを削除する
 |===
 
+[#environments-and-business-groups-commands]
 == 環境およびビジネスグループを指定するコマンド
 
 [%header,cols="35a,65a"]

--- a/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
@@ -29,6 +29,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 コマンドの後に `--fields` オプションを渡して、出力可能なすべての項目のリストを取得できます。
 --
 
+[#platform-account-commands]
 == Anypoint Platform アカウントを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -43,6 +44,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<account environment describe>> | 環境の詳細を表示する
 |===
 
+[#api-manager-commands]
 == API Manager のコマンド
 
 [%header,cols="35a,65a"]
@@ -86,6 +88,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<api-mgr proxy download>> | プロキシの ZIP アーカイブをローカルディレクトリにダウンロードする
 |===
 
+[#design-center-applications-commands]
 == Design Center アプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -99,6 +102,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 | <<designcenter project list>> | すべての Design Center プロジェクトをリストする
 |===
 
+[#exchange-assets-commands]
 == Exchange アセットを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -120,6 +124,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 |<<exchange asset describe>> | 特定のアセットの情報を表示する
 |===
 
+[#cloudhub-application-commands]
 == CloudHub アプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -144,6 +149,7 @@ Anypoint Platform CLI には、3 つのデフォルトオプションがあり�
 // |<<runtime-mgr cloudhub-application downgrade-runtime>>| Downgrades application runtime to the previous runtime version or if a version is specified, to that version.
 |===
 
+[#local-applications-runtime-manager-commands]
 == Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションを管理するコマンド
 
 [CAUTION]
@@ -165,6 +171,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr standalone-application copy>> | スタンドアロンアプリケーションをコピーする
 |===
 
+[#local-pcf-applications-commands]
 == ローカル Pivotal Cloud Foundry デプロイ済みアプリケーションを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -182,6 +189,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |===
 
 
+[#local-servers-commands]
 == ローカルサーバを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -195,6 +203,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 // |<<runtime-mgr server register>> | Registers a new server. Returns a signed certificate which is downloaded to the `directory` path
 |===
 
+[#local-server-groups-commands]
 == ローカルサーバグループを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -209,6 +218,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr serverGroup remove server>> | サーバグループのサーバを削除する
 |===
 
+[#local-cluster-servers-commands]
 == ローカルクラスタサーバを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -224,6 +234,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |===
 
 
+[#alerts-local-applications-runtime-manager-commands]
 == Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションのアラートを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -235,6 +246,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<runtime-mgr standalone-alert list>> | 環境内のスタンドアロンランタイムのすべてのアラートをリストする
 |===
 
+[#cloudhub-dedicated-load-balancer-commands]
 == CloudHub 専用ロードバランサを管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -262,6 +274,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<cloudhub runtime list>>| 使用可能なすべてのランタイムをリストする
 |===
 
+[#cloudhub-vpc-commands]
 == CloudHub VPC を管理するコマンド
 
 [%header,cols="35a,65a"]
@@ -283,6 +296,7 @@ Anypoint Platform CLI で対象サーバを認識できるように、手動で�
 |<<cloudhub vpc firewall-rules remove>>| この VPC の Mule アプリケーションのファイアウォールルールを削除する
 |===
 
+[#environments-and-business-groups-commands]
 == 環境およびビジネスグループを指定するコマンド
 
 [%header,cols="35a,65a"]

--- a/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
@@ -390,7 +390,7 @@ $ anypoint-cli [params] [command]
 
 このコマンドでは、デフォルトのオプション (`--help`、`-f`/`--fields`、`-o`/`--output`) 以外のオプションは使用できません。
 
-== account environment delete
+== account environment describe
 
 ----
 > account environment describe [options] <name>

--- a/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli2-commands.adoc
@@ -2,20 +2,20 @@
 
 Anypoint Platform CLI には、さまざまなユースケースシナリオに対応するコマンドが用意されています。
 
-* <<Commands For Administrating your Anypoint Platform Account>>
-* <<Commands for API Manager>>
-* <<Commands for Administrating your Design Center Applications>>
-* <<Commands for Managing Exchange Assets>>
-* <<Commands for Administrating your CloudHub Application>>
-* <<Commands for Managing your Locally Deployed Applications Managed by Runtime Manager>>
-* <<Commands for Managing Your Local Pivotal Cloud Foundry Deployed Applications>>
-* <<Commands for Managing your Local Servers>>
-* <<Commands for Administrating your Local Server Groups>>
-* <<Commands for Administrating your Local Cluster Servers>>
-* <<Commands for Managing Alerts for your Locally Deployed Applications Managed by Runtime Manager>>
-* <<Commands for Mananging your CloudHub Dedicated Load Balancer>>
-* <<Commands for Managing your CloudHub Anypoint Virtual Private Cloud (VPC)>>
-* <<Commands for Specifying Environments and Business Groups>>
+* <<platform-account-commands,Anypoint Platform アカウントを管理するコマンド>>
+* <<api-manager-commands,API Manager のコマンド>>
+* <<design-center-applications-commands,Design Center アプリケーションを管理するコマンド>>
+* <<exchange-assets-commands,Exchange アセットを管理するコマンド>>
+* <<cloudhub-application-commands,CloudHub アプリケーションを管理するコマンド>>
+* <<local-applications-runtime-manager-commands,Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションを管理するコマンド>>
+* <<local-pcf-applications-commands,ローカル Pivotal Cloud Foundry デプロイ済みアプリケーションを管理するコマンド>>
+* <<local-servers-commands,ローカルサーバを管理するコマンド>>
+* <<local-server-groups-commands,ローカルサーバグループを管理するコマンド>>
+* <<local-cluster-servers-commands,ローカルクラスタサーバを管理するコマンド>>
+* <<alerts-local-applications-runtime-manager-commands,Runtime Manager の管理下にある、ローカルにデプロイされているアプリケーションのアラートを管理するコマンド>>
+* <<cloudhub-dedicated-load-balancer-commands,CloudHub 専用ロードバランサを管理するコマンド>>
+* <<cloudhub-vpc-commands,CloudHub VPC を管理するコマンド>>
+* <<environments-and-business-groups-commands,環境およびビジネスグループを指定するコマンド>>
 
 
 [TIP]


### PR DESCRIPTION
This is probably the best way to address anchor links considering that the subtitles are being translated. 

~I'm keeping this PR opens as I also send fixes for the list of commands in CLI 3.x.~
See: e29ba54

